### PR TITLE
Modified bech32 address prefixes

### DIFF
--- a/eqbtest/functional/test_framework/address.py
+++ b/eqbtest/functional/test_framework/address.py
@@ -58,7 +58,7 @@ def program_to_witness(version, program, main = False):
     assert 0 <= version <= 16
     assert 2 <= len(program) <= 40
     assert version > 0 or len(program) in [20, 32]
-    return segwit_addr.encode("bc" if main else "ocnregtest", version, program)
+    return segwit_addr.encode("bc" if main else "rttesr", version, program)
 
 def script_to_p2wsh(script, main = False):
     script = check_script(script)

--- a/eqbtest/functional/wallet_disable.py
+++ b/eqbtest/functional/wallet_disable.py
@@ -22,14 +22,14 @@ class DisableWalletTest (BitcoinTestFramework):
         assert_raises_rpc_error(-32601, 'Method not found', self.nodes[0].getwalletinfo)
         x = self.nodes[0].validateaddress('3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')
         assert(x['isvalid'] == False)
-        x = self.nodes[0].validateaddress('ocnregtest1qzpz2y7gcj2hgker0uwqzlaarydmcv77ljrpx2q')
+        x = self.nodes[0].validateaddress('rttesr1qhwkhpm0klxryn3226k9uws0ll8gasqfevcgtxa')
         assert(x['isvalid'] == True)
         x = self.nodes[0].validateaddress('TQaZkHaCbX4e8BoVJBabg7PahUM9CDXwthyK')  # Testnet regular address
         assert (x['isvalid'] == True)
 
         # Checking mining to an address without a wallet. Generating to a valid address should succeed
         # but generating to an invalid address will fail.
-        self.nodes[0].generatetoaddress(1, 'ocnregtest1qzpz2y7gcj2hgker0uwqzlaarydmcv77ljrpx2q')
+        self.nodes[0].generatetoaddress(1, 'rttesr1qhwkhpm0klxryn3226k9uws0ll8gasqfevcgtxa')
         assert_raises_rpc_error(-5, "Invalid address", self.nodes[0].generatetoaddress, 1, '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')
 
 if __name__ == '__main__':

--- a/eqbtest/util/data/txcreatemultisig3.json
+++ b/eqbtest/util/data/txcreatemultisig3.json
@@ -17,7 +17,7 @@
                 "reqSigs": 1,
                 "type": "witness_v0_scripthash",
                 "addresses": [
-                    "ocn1qsvcfg2u7906ey43zqwsj8ssev3ej5ff5x6rf39k0fu6046v3rnush5vx3h"
+                    "tesr1qsvcfg2u7906ey43zqwsj8ssev3ej5ff5x6rf39k0fu6046v3rnuslkpeu6"
                 ]
             }
         }

--- a/eqbtest/util/data/txcreateoutpubkey2.json
+++ b/eqbtest/util/data/txcreateoutpubkey2.json
@@ -17,7 +17,7 @@
                 "reqSigs": 1,
                 "type": "witness_v0_keyhash",
                 "addresses": [
-                    "ocn1qvxsxt06rneh286hdqgm964wxpxve05y32ll4vq"
+                    "tesr1qvxsxt06rneh286hdqgm964wxpxve05y3aau5zv"
                 ]
             }
         }

--- a/eqbtest/util/data/txcreatescript3.json
+++ b/eqbtest/util/data/txcreatescript3.json
@@ -17,7 +17,7 @@
                 "reqSigs": 1,
                 "type": "witness_v0_scripthash",
                 "addresses": [
-                    "ocn1q6l55dq5svuezzfykw0ftstpukvtgrx5yjmp09karat4aj3m673xquxm358"
+                    "tesr1q6l55dq5svuezzfykw0ftstpukvtgrx5yjmp09karat4aj3m673xq5ykwe2"
                 ]
             }
         }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -490,7 +490,7 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = { 0x04, 0x88, 0xB2, 0x1E }; // "xpub" Same as Bitcoin
         base58Prefixes[EXT_SECRET_KEY] = { 0x04, 0x88, 0xAD, 0xE4 }; // "xprv" Same as Bitcoin
 
-        bech32_hrp = "ocn";
+        bech32_hrp = "tesr";
 
         // TESR_TODO populate fixed seeds for Tesseract network
         // vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_main, pnSeed6_main + ARRAYLEN(pnSeed6_main));
@@ -582,7 +582,7 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = { 0x04, 0x35, 0x87, 0xCF };  // Same as Bitcoin
         base58Prefixes[EXT_SECRET_KEY] = { 0x04, 0x35, 0x83, 0x94 };  // Same as Bitcoin
 
-        bech32_hrp = "ocntestnet";
+        bech32_hrp = "tntesr";
 
         // TESR_TODO
         // vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_test, pnSeed6_test + ARRAYLEN(pnSeed6_test));
@@ -684,7 +684,7 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = { 0x04, 0x35, 0x87, 0xCF };  // 'tpub' Same as Bitcoin
         base58Prefixes[EXT_SECRET_KEY] = { 0x04, 0x35, 0x83, 0x94 };  // 'tprv' Same as Bitcoin
 
-        bech32_hrp = "ocnregtest";
+        bech32_hrp = "rttesr";
     }
 };
 


### PR DESCRIPTION
Related to #1 ... I'm deferring changing the legacy address prefixes until we come to a consensus because there is a lot more work in updating the automated tests.